### PR TITLE
Embed keywords in document metadata

### DIFF
--- a/docs/manual.typ
+++ b/docs/manual.typ
@@ -66,7 +66,7 @@ After importing #package[elsearticle], you have to initialize the template by a 
   authors: (),
   abstract: none,
   journal: none,
-  keywords: none,
+  keywords: (),
   format: "preprint",
   numcol: 1,
   line-numbering: false,
@@ -103,7 +103,7 @@ authors: (
 
 #argument("journal", default: none, types: "string")[Name of the journal]
 
-#argument("keywords", default: none, types: "array")[List of the keywords of the paper
+#argument("keywords", default: (), types: "array")[List of the keywords of the paper
 
 Each element of the #dtype("array") is a #dtype("string") representing a keyword
 

--- a/src/els-template-info.typ
+++ b/src/els-template-info.typ
@@ -66,7 +66,7 @@
     if els-format.type.contains("review") {v(0.5em)} else {v(-0.2em)}
     abstract
     if els-format.type.contains("review") {linebreak()} else {v(0em)}
-    if keywords != none {
+    if keywords != () {
       let kw = ()
       for keyword in keywords{
         kw.push(keyword)

--- a/src/elsearticle.typ
+++ b/src/elsearticle.typ
@@ -25,7 +25,7 @@
   journal: none,
 
   // Keywords
-  keywords: none,
+  keywords: (),
 
   // For integrating future formats (1p, 3p, 5p, final)
   format: "review",
@@ -123,7 +123,11 @@
   let els-info = template-info(title, abstract, authors, keywords, els-columns, els-format)
 
   // Set document metadata.
-  set document(title: title, author: els-info.els-meta)
+  set document(
+    title: title,
+    author: els-info.els-meta,
+    keywords: keywords,
+  )
 
   // Corresponding author
   hide(footnote(els-info.coord, numbering: "*"))


### PR DESCRIPTION
If the user has specified keywords, these should be embedded in the generated PDF through the `document` element ([reference][0]). The keywords variable then needs to be initialized to `()` rather than `none` to minimize breakage elsewhere.

Manual entry updated.

[0]: https://typst.app/docs/reference/model/document/#parameters-keywords